### PR TITLE
Allow adding config files to supervisor

### DIFF
--- a/assets/etc/supervisord.conf
+++ b/assets/etc/supervisord.conf
@@ -6,3 +6,6 @@ group=root
 [program:sshd]
 command=/usr/local/sbin/sshd_foreground
 autorestart=true
+
+[include]
+files = /etc/supervisor/conf.d/*.conf


### PR DESCRIPTION
Allows for something like:

```ruby
Vagrant.configure("2") do |config|
  config.vm.hostname = "ubuntu"

  config.vm.provider :docker do |docker, override|
    override.vm.box = nil
    docker.image = "rofrano/vagrant-provider:ubuntu"
    docker.remains_running = true
    docker.has_ssh = true
    docker.privileged = true
    #docker.create_args = ['--platform=linux/arm64']
  end

  config.vm.network "forwarded_port", guest: 80, host: 80
  config.vm.provision "shell", path: "provision.sh", name: "packages"
end
```

```shell
#!/usr/bin/env bash
set -eu
sudo apt-get update
sudo apt-get -y install apache2
sudo apt-get -qq clean

printf '[program:apache2]
command=/usr/sbin/apache2ctl -DFOREGROUND' | sudo tee /etc/supervisor/conf.d/apache2.conf
```

Which will mean apache would be stared on `docker stop` and `docker start`