### PR TITLE
Fixed Docker 4.3 breakage with systemd changes

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,6 +1,6 @@
 # Build with:
 # docker buildx build --platform linux/amd64,linux/arm64 --push --tag rofrano/vagrant-provider:debian .
-FROM debian:buster
+FROM debian:11
 LABEL MAINTAINER="John Rofrano <rofrano@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:21.10
 LABEL MAINTAINER="John Rofrano <rofrano@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,9 +13,15 @@ Vagrant.configure(2) do |config|
     docker.remains_running = true
     docker.has_ssh = true
     docker.privileged = true
-    docker.volumes = ["/sys/fs/cgroup:/sys/fs/cgroup:ro"]
+    docker.volumes = ["/sys/fs/cgroup:/sys/fs/cgroup:rw"]
+    docker.create_args = ["--cgroupns=host"]
     # Uncomment to force arm64 for testing images on Intel
     # docker.create_args = ["--platform=linux/arm64"]     
   end  
+
+  # Install Docker and pull an image
+  # config.vm.provision :docker do |d|
+  #   d.pull_images "alpine:latest"
+  # end
 
 end


### PR DESCRIPTION
Make the following changes to be compatible with updates that Docker Desktop 4.3 made to systemd support which now requires `systemd` 247 or greater:

- Updated the Ubuntu image to 21.10 for `systemd` version 249
- Updated the Debian image to 11 for `systemd` version 247
- Changed `Vagrantfile` to mount `/sys/fs/cgroup` read-write
- Added `--cgroupns=host` docker argument to run Docker in Docker