### PR TITLE
Change base image to ubuntu 24

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 LABEL MAINTAINER="John Rofrano <rofrano@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Built image:

```
zulhfreelancer/vagrant-provider:ubuntu
```

Version check:

```
$ vagrant ssh
Welcome to Ubuntu 24.04 LTS (GNU/Linux 6.10.0-linuxkit x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro
Last login: Sun Aug 25 10:17:17 2024 from 172.17.0.1
vagrant@ubuntu:~$ uname -a
Linux ubuntu 6.10.0-linuxkit #1 SMP PREEMPT_DYNAMIC Wed Jul 17 10:54:05 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
vagrant@ubuntu:~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04 LTS
Release:	24.04
Codename:	noble
vagrant@ubuntu:~$
```